### PR TITLE
refactor: unify API endpoints and token handling

### DIFF
--- a/src/components/services/investorService.jsx
+++ b/src/components/services/investorService.jsx
@@ -4,12 +4,12 @@ import { apiClient, API_ENDPOINTS } from '../utils/api';
 export class InvestorService {
   // Register new investor
   static async register(investorData) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_REGISTER, investorData);
+    return await apiClient.post(API_ENDPOINTS.investors.register, investorData);
   }
 
   // Login investor
   static async login(credentials) {
-    const response = await apiClient.post(API_ENDPOINTS.INVESTOR_LOGIN, credentials);
+    const response = await apiClient.post(API_ENDPOINTS.auth.login, credentials);
     if (response.token) {
       apiClient.setToken(response.token);
     }
@@ -18,60 +18,60 @@ export class InvestorService {
 
   // Send SMS verification code
   static async sendVerificationCode(phone) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_VERIFY_PHONE, { phone });
+    return await apiClient.post(API_ENDPOINTS.investors.verifyPhone, { phone });
   }
 
   // Verify phone number with OTP
   static async verifyPhone(investorId, code) {
-    return await apiClient.post(`${API_ENDPOINTS.INVESTOR_BY_ID(investorId)}/verify`, { code });
+    return await apiClient.post(API_ENDPOINTS.investors.verify(investorId), { code });
   }
 
   // Forgot Password
   static async forgotPassword(email) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_FORGOT_PASSWORD, { email });
+    return await apiClient.post(API_ENDPOINTS.investors.forgotPassword, { email });
   }
 
   // Reset Password
   static async resetPassword(token, password) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_RESET_PASSWORD, { token, password });
+    return await apiClient.post(API_ENDPOINTS.investors.resetPassword, { token, password });
   }
 
   // Send email confirmation
   static async sendEmailConfirmation(email) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_SEND_EMAIL_CONFIRMATION, { email });
+    return await apiClient.post(API_ENDPOINTS.investors.sendEmailConfirmation, { email });
   }
 
   // Verify email with token
   static async verifyEmail(token) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_VERIFY_EMAIL, { token });
+    return await apiClient.post(API_ENDPOINTS.investors.verifyEmail, { token });
   }
 
   // Resend email confirmation
   static async resendEmailConfirmation(email) {
-    return await apiClient.post(API_ENDPOINTS.INVESTOR_RESEND_EMAIL_CONFIRMATION, { email });
+    return await apiClient.post(API_ENDPOINTS.investors.resendEmailConfirmation, { email });
   }
 
   // Get current investor profile
   static async getProfile() {
-    return await apiClient.get('/investors/me');
+    return await apiClient.get(API_ENDPOINTS.investors.me);
   }
 
   // Get investor by ID
   static async getById(investorId) {
-    return await apiClient.get(API_ENDPOINTS.INVESTOR_BY_ID(investorId));
+    return await apiClient.get(API_ENDPOINTS.investors.byId(investorId));
   }
 
   // Update investor
   static async update(investorId, updateData) {
-    return await apiClient.put(API_ENDPOINTS.INVESTOR_BY_ID(investorId), updateData);
+    return await apiClient.put(API_ENDPOINTS.investors.byId(investorId), updateData);
   }
 
   // Get leads for investor
   static async getLeads(investorId, filters = {}) {
     const queryParams = new URLSearchParams(filters).toString();
-    const endpoint = queryParams 
-      ? `${API_ENDPOINTS.INVESTOR_LEADS(investorId)}?${queryParams}` 
-      : API_ENDPOINTS.INVESTOR_LEADS(investorId);
+    const endpoint = queryParams
+      ? `${API_ENDPOINTS.investors.leads(investorId)}?${queryParams}`
+      : API_ENDPOINTS.investors.leads(investorId);
     return await apiClient.get(endpoint);
   }
 
@@ -84,7 +84,7 @@ export class InvestorService {
 
   // Get all investors (admin only)
   static async list() {
-    return await apiClient.get(API_ENDPOINTS.INVESTORS);
+    return await apiClient.get(API_ENDPOINTS.investors.base);
   }
 }
 

--- a/src/components/services/offerService.jsx
+++ b/src/components/services/offerService.jsx
@@ -3,42 +3,42 @@ import { apiClient, API_ENDPOINTS } from '../utils/api';
 export class OfferService {
   // Make new offer on property
   static async makeOffer(offerData) {
-    return await apiClient.post(API_ENDPOINTS.MAKE_OFFER, offerData);
+    return await apiClient.post(API_ENDPOINTS.offers.base, offerData);
   }
 
   // Get offer by ID
   static async getById(offerId) {
-    return await apiClient.get(API_ENDPOINTS.OFFER_BY_ID(offerId));
+    return await apiClient.get(API_ENDPOINTS.offers.byId(offerId));
   }
 
   // Accept offer (seller action)
   static async acceptOffer(offerId) {
-    return await apiClient.post(API_ENDPOINTS.ACCEPT_OFFER(offerId));
+    return await apiClient.post(API_ENDPOINTS.offers.accept(offerId));
   }
 
   // Counter offer (seller action)
   static async counterOffer(offerId, counterAmount) {
-    return await apiClient.post(API_ENDPOINTS.COUNTER_OFFER(offerId), { amount: counterAmount });
+    return await apiClient.post(API_ENDPOINTS.offers.counter(offerId), { amount: counterAmount });
   }
 
   // Withdraw offer (investor action)
   static async withdrawOffer(offerId) {
-    return await apiClient.post(API_ENDPOINTS.WITHDRAW_OFFER(offerId));
+    return await apiClient.post(API_ENDPOINTS.offers.withdraw(offerId));
   }
 
   // Update offer
   static async update(offerId, updateData) {
-    return await apiClient.put(API_ENDPOINTS.OFFER_BY_ID(offerId), updateData);
+    return await apiClient.put(API_ENDPOINTS.offers.byId(offerId), updateData);
   }
 
   // Get offers for a property
   static async getPropertyOffers(propertyId) {
-    return await apiClient.get(`/properties/${propertyId}/offers`);
+    return await apiClient.get(API_ENDPOINTS.properties.offers(propertyId));
   }
 
   // Get offers made by investor
   static async getInvestorOffers(investorId) {
-    return await apiClient.get(`/investors/${investorId}/offers`);
+    return await apiClient.get(API_ENDPOINTS.investors.offers(investorId));
   }
 }
 

--- a/src/components/services/propertyService.jsx
+++ b/src/components/services/propertyService.jsx
@@ -3,17 +3,17 @@ import { apiClient, API_ENDPOINTS } from '../utils/api';
 export class PropertyService {
   // Create new property
   static async create(propertyData) {
-    return await apiClient.post(API_ENDPOINTS.PROPERTIES, propertyData);
+    return await apiClient.post(API_ENDPOINTS.properties.base, propertyData);
   }
 
   // Get property by ID
   static async getById(propertyId) {
-    return await apiClient.get(API_ENDPOINTS.PROPERTY_BY_ID(propertyId));
+    return await apiClient.get(API_ENDPOINTS.properties.byId(propertyId));
   }
 
   // Update property
   static async update(propertyId, updateData) {
-    return await apiClient.put(API_ENDPOINTS.PROPERTY_BY_ID(propertyId), updateData);
+    return await apiClient.put(API_ENDPOINTS.properties.byId(propertyId), updateData);
   }
 
   // Upload property photos
@@ -26,14 +26,14 @@ export class PropertyService {
         categoryPhotos.forEach((photo, index) => {
           if (photo instanceof File) {
             uploadPromises.push(
-              apiClient.uploadFile(API_ENDPOINTS.UPLOAD_PHOTOS(propertyId), photo)
+              apiClient.uploadFile(API_ENDPOINTS.properties.uploadPhotos(propertyId), photo)
                 .then(result => ({ category, index, ...result }))
             );
           }
         });
       } else if (categoryPhotos instanceof File) {
         uploadPromises.push(
-          apiClient.uploadFile(API_ENDPOINTS.UPLOAD_PHOTOS(propertyId), categoryPhotos)
+          apiClient.uploadFile(API_ENDPOINTS.properties.uploadPhotos(propertyId), categoryPhotos)
             .then(result => ({ category, ...result }))
         );
       }
@@ -45,13 +45,13 @@ export class PropertyService {
   // Get all properties
   static async list(filters = {}) {
     const queryParams = new URLSearchParams(filters).toString();
-    const endpoint = queryParams ? `${API_ENDPOINTS.PROPERTIES}?${queryParams}` : API_ENDPOINTS.PROPERTIES;
+    const endpoint = queryParams ? `${API_ENDPOINTS.properties.base}?${queryParams}` : API_ENDPOINTS.properties.base;
     return await apiClient.get(endpoint);
   }
 
   // Delete property
   static async delete(propertyId) {
-    return await apiClient.delete(API_ENDPOINTS.PROPERTY_BY_ID(propertyId));
+    return await apiClient.delete(API_ENDPOINTS.properties.byId(propertyId));
   }
 }
 

--- a/src/components/services/sellerService.js
+++ b/src/components/services/sellerService.js
@@ -3,32 +3,32 @@ import { apiClient, API_ENDPOINTS } from '../utils/api';
 export class SellerService {
   // Register new seller
   static async register(sellerData) {
-    return await apiClient.post(API_ENDPOINTS.SELLER_REGISTER, sellerData);
+    return await apiClient.post(API_ENDPOINTS.sellers.register, sellerData);
   }
 
   // Send SMS verification code — backend expects both name and phone
   static async sendVerificationCode(name, phone) {
-    return await apiClient.post(API_ENDPOINTS.SELLER_VERIFY_PHONE, { name, phone });
+    return await apiClient.post(API_ENDPOINTS.sellers.verifyPhone, { name, phone });
   }
 
   // Verify phone number with OTP
   static async verifyPhone(phone, code) {
-    return await apiClient.post(API_ENDPOINTS.SELLER_VERIFY_CODE, { phone, code });
+    return await apiClient.post(API_ENDPOINTS.sellers.verifyCode, { phone, code });
   }
 
   // Get seller by ID
   static async getById(sellerId) {
-    return await apiClient.get(API_ENDPOINTS.SELLER_BY_ID(sellerId));
+    return await apiClient.get(API_ENDPOINTS.sellers.byId(sellerId));
   }
 
   // Update seller
   static async update(sellerId, updateData) {
-    return await apiClient.put(API_ENDPOINTS.SELLER_BY_ID(sellerId), updateData);
+    return await apiClient.put(API_ENDPOINTS.sellers.byId(sellerId), updateData);
   }
 
   // Get all sellers (admin only)
   static async list() {
-    return await apiClient.get(API_ENDPOINTS.SELLERS);
+    return await apiClient.get(API_ENDPOINTS.sellers.base);
   }
 }
 

--- a/src/components/services/sellerService.jsx
+++ b/src/components/services/sellerService.jsx
@@ -3,32 +3,32 @@ import { apiClient, API_ENDPOINTS } from '../utils/api';
 export class SellerService {
   // Register new seller
   static async register(sellerData) {
-    return await apiClient.post(API_ENDPOINTS.SELLER_REGISTER, sellerData);
+    return await apiClient.post(API_ENDPOINTS.sellers.register, sellerData);
   }
 
   // Send SMS verification code
   static async sendVerificationCode(phone) {
-    return await apiClient.post(API_ENDPOINTS.SELLER_VERIFY_PHONE, { phone });
+    return await apiClient.post(API_ENDPOINTS.sellers.verifyPhone, { phone });
   }
 
   // Verify phone number with OTP
   static async verifyPhone(sellerId, code) {
-    return await apiClient.post(`${API_ENDPOINTS.SELLER_BY_ID(sellerId)}/verify`, { code });
+    return await apiClient.post(API_ENDPOINTS.sellers.verify(sellerId), { code });
   }
 
   // Get seller by ID
   static async getById(sellerId) {
-    return await apiClient.get(API_ENDPOINTS.SELLER_BY_ID(sellerId));
+    return await apiClient.get(API_ENDPOINTS.sellers.byId(sellerId));
   }
 
   // Update seller
   static async update(sellerId, updateData) {
-    return await apiClient.put(API_ENDPOINTS.SELLER_BY_ID(sellerId), updateData);
+    return await apiClient.put(API_ENDPOINTS.sellers.byId(sellerId), updateData);
   }
 
   // Get all sellers (admin only)
   static async list() {
-    return await apiClient.get(API_ENDPOINTS.SELLERS);
+    return await apiClient.get(API_ENDPOINTS.sellers.base);
   }
 }
 

--- a/src/components/utils/api.jsx
+++ b/src/components/utils/api.jsx
@@ -8,12 +8,18 @@ export const apiClient = axios.create({
   withCredentials: false,
 });
 
+export const setToken = (token) => {
+  if (token) {
+    apiClient.defaults.headers.common.Authorization = `Bearer ${token}`;
+  } else {
+    delete apiClient.defaults.headers.common.Authorization;
+  }
+};
+
+apiClient.setToken = setToken;
+
 export const API_ENDPOINTS = {
   health: "/health",
-  investors: "/investors",
-  sellers: "/sellers",
-  leads: "/leads",
-  properties: "/properties",
   auth: {
     login: "/auth/login",
     logout: "/auth/logout",
@@ -21,6 +27,42 @@ export const API_ENDPOINTS = {
     register: "/auth/register",
     forgot: "/auth/forgot-password",
     reset: "/auth/reset-password",
+  },
+  investors: {
+    base: "/investors",
+    register: "/investors/register",
+    verifyPhone: "/investors/verify-phone",
+    forgotPassword: "/investors/forgot-password",
+    resetPassword: "/investors/reset-password",
+    sendEmailConfirmation: "/investors/send-email-confirmation",
+    verifyEmail: "/investors/verify-email",
+    resendEmailConfirmation: "/investors/resend-email-confirmation",
+    me: "/investors/me",
+    byId: (id) => `/investors/${id}`,
+    leads: (id) => `/investors/${id}/leads`,
+    offers: (id) => `/investors/${id}/offers`,
+    verify: (id) => `/investors/${id}/verify`,
+  },
+  sellers: {
+    base: "/sellers",
+    register: "/sellers/register",
+    verifyPhone: "/sellers/verify-phone",
+    verifyCode: "/sellers/verify-code",
+    byId: (id) => `/sellers/${id}`,
+    verify: (id) => `/sellers/${id}/verify`,
+  },
+  properties: {
+    base: "/properties",
+    byId: (id) => `/properties/${id}`,
+    uploadPhotos: (id) => `/properties/${id}/photos`,
+    offers: (id) => `/properties/${id}/offers`,
+  },
+  offers: {
+    base: "/offers",
+    byId: (id) => `/offers/${id}`,
+    accept: (id) => `/offers/${id}/accept`,
+    counter: (id) => `/offers/${id}/counter`,
+    withdraw: (id) => `/offers/${id}/withdraw`,
   },
 };
 


### PR DESCRIPTION
## Summary
- add `setToken` helper and restructure API endpoints
- update services to use nested `API_ENDPOINTS` paths

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 68 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689c89badb808325b594ecf86b60b574