### PR TITLE
Use auth context for investor login

### DIFF
--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -33,14 +33,18 @@ export const AuthProvider = ({ children }) => {
       .finally(() => setLoading(false));
   }, []);
 
-  const login = async (newToken) => {
+  const login = async (newToken, userData) => {
     localStorage.setItem("token", newToken);
     setToken(newToken);
     apiClient.defaults.headers.common["Authorization"] = `Bearer ${newToken}`;
     setLoading(true);
     try {
-      const { data } = await apiClient.get(API_ENDPOINTS.auth.me);
-      setUser(data);
+      if (userData) {
+        setUser(userData);
+      } else {
+        const { data } = await apiClient.get(API_ENDPOINTS.auth.me);
+        setUser(data);
+      }
       setIsAuthenticated(true);
     } finally {
       setLoading(false);

--- a/src/pages/InvestorLogin.jsx
+++ b/src/pages/InvestorLogin.jsx
@@ -9,6 +9,7 @@ import { InvestorService } from '@/components/services/investorService';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { useToast } from '@/components/common/Toast';
 import { useFormValidation, ValidatedInput, validationRules } from '@/components/common/FormValidation';
+import { useAuth } from '@/components/hooks/useAuth';
 
 const AnimatedTurtle = () => (
   <div className="text-6xl">
@@ -19,6 +20,7 @@ const AnimatedTurtle = () => (
 export default function InvestorLogin() {
   const navigate = useNavigate();
   const { success, error } = useToast();
+  const { login: authLogin } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -52,13 +54,12 @@ export default function InvestorLogin() {
         navigate(createPageUrl(`EmailConfirmation?email=${encodeURIComponent(response.user.email)}`));
         return;
       }
-      
-      localStorage.setItem('investorId', response.user.id);
-      localStorage.setItem('investorEmail', response.user.email);
+
+      await authLogin(response.token, response.user);
       success('Login successful! Redirecting to dashboard...');
       navigate(createPageUrl('InvestorDashboard'));
     } catch (err) {
-      error(err.message || 'Invalid email or password'); 
+      error(err.message || 'Invalid email or password');
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- use auth context to log in investors and persist JWT
- allow auth login to accept user data when available

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c8dd014ac832581e7f9c57856c68b