### PR TITLE
Call InvestorService logout before context logout

### DIFF
--- a/src/components/common/LayoutComponent.jsx
+++ b/src/components/common/LayoutComponent.jsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useAuth } from '@/auth/AuthProvider.jsx';
 import { LogIn, LogOut, UserPlus, LayoutDashboard } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { InvestorService } from '@/components/services/investorService';
 
 const navLinks = [
   { name: 'Home', path: createPageUrl('Home') },
@@ -63,7 +64,12 @@ const Header = ({ currentPageName }) => {
                   <LayoutDashboard className="w-4 h-4 mr-2" />
                   Dashboard
                 </Button>
-                <Button onClick={logout}>
+                <Button
+                  onClick={async () => {
+                    await InvestorService.logout();
+                    logout();
+                  }}
+                >
                   <LogOut className="w-4 h-4 mr-2" />
                   Logout
                 </Button>

--- a/src/components/services/investorService.jsx
+++ b/src/components/services/investorService.jsx
@@ -78,6 +78,7 @@ export class InvestorService {
   // Logout
   static async logout() {
     apiClient.setToken(null);
+    localStorage.removeItem('token');
     localStorage.removeItem('investorId');
     localStorage.removeItem('investorEmail');
   }


### PR DESCRIPTION
## Summary
- route LayoutComponent's logout button through InvestorService.logout before clearing auth context
- purge stored JWT in InvestorService.logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c90559d8483259148840f685d0c1e