### PR TITLE
feat: add dev proxy for API requests

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -5,6 +5,14 @@ import { defineConfig } from "vite"
 export default defineConfig({
   plugins: [react()],
   resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true
+      }
+    }
+  },
   test: {
     environment: "jsdom"
   }


### PR DESCRIPTION
## Summary
- proxy /api requests to http://localhost:5000 during dev

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 58 errors, 4 warnings)*
- `curl -i http://localhost:5174/api/test`


------
https://chatgpt.com/codex/tasks/task_e_689ca17cd4e48325813f3887017cc79c