### PR TITLE
chore: fix nginx proxy backend

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,7 @@ server {
 
   # Proxy API calls to backend (adjust if your backend port changes)
   location ^~ /api/ {
-    proxy_pass http://127.0.0.1:5000/\;
+    proxy_pass http://backend:5000/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- fix nginx config to point API proxy at backend:5000

## Testing
- `npm test` (no test files)
- `npm run lint` *(fails: 53 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ca45e35a48325a8ee0d517d9d278e