### PR TITLE
feat: add multi-stage Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Dependencies
+node_modules
+
+# Build output
+/dist
+/build
+.vite
+
+# Git
+.git
+.gitignore
+
+# Environment files
+.env
+.env.*
+
+# Logs
+*.log
+npm-debug.log*
+yarn-error.log*
+
+# Docker and compose files
+docker-compose.yml
+
+# Misc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM nginx:alpine
-WORKDIR /usr/share/nginx/html
-COPY dist .
+# Stage 1: Build the Vite project
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve with Nginx
+FROM nginx:alpine AS runtime
+# Copy build output
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Custom Nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Docker
+
+To build and run the production container:
+
+```bash
+ docker-compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   frontend:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
     container_name: moolahturtle-frontend
     ports:
       - "8080:80"


### PR DESCRIPTION
## Summary
- build Vite app in node 20 then serve with nginx
- ignore unnecessary files in Docker context
- update compose to run runtime stage
- document docker usage

## Testing
- `npx vitest run` (fails: No test files found)
- `npm run lint` (fails: 57 problems)

------
https://chatgpt.com/codex/tasks/task_e_689ca5ff65a08325b9efe951a8df49a3