### PR TITLE
Use destructured login response in investor login flow

### DIFF
--- a/src/pages/InvestorLogin.jsx
+++ b/src/pages/InvestorLogin.jsx
@@ -45,17 +45,17 @@ export default function InvestorLogin() {
     setIsLoading(true);
     
     try {
-      const response = await InvestorService.login(form.values);
-      
+      const { token, user } = await InvestorService.login(form.values);
+
       // Check if email is verified
-      if (!response.user.email_verified) {
+      if (!user.email_verified) {
         error('Please verify your email address before logging in.');
         // Redirect to email confirmation page
-        navigate(createPageUrl(`EmailConfirmation?email=${encodeURIComponent(response.user.email)}`));
+        navigate(createPageUrl(`EmailConfirmation?email=${encodeURIComponent(user.email)}`));
         return;
       }
 
-      await authLogin(response.token, response.user);
+      await authLogin(token, user);
       success('Login successful! Redirecting to dashboard...');
       navigate(createPageUrl('InvestorDashboard'));
     } catch (err) {


### PR DESCRIPTION
## Summary
- Destructure `token` and `user` from `InvestorService.login`
- Verify email using `user.email_verified` and pass token/user to `authLogin`

## Testing
- `npm test` *(no tests found)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3382c0083259a135ad90882bc50