### PR TITLE
feat: add window logout event listener

### DIFF
--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -59,6 +59,12 @@ export const AuthProvider = ({ children }) => {
     setIsAuthenticated(false);
   };
 
+  useEffect(() => {
+    const handleLogout = () => logout();
+    window.addEventListener("logout", handleLogout);
+    return () => window.removeEventListener("logout", handleLogout);
+  }, [logout]);
+
   return (
     <Ctx.Provider value={{ isAuthenticated, user, token, loading, login, logout }}>
       {children}


### PR DESCRIPTION
## Summary
- listen for `logout` events from `window` and trigger provider logout

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: 'motion' is defined but never used, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cb80312208325852f26ebb2cbdad9