### PR TITLE
Verify investor phone with service call

### DIFF
--- a/src/components/investors/RegistrationForm.jsx
+++ b/src/components/investors/RegistrationForm.jsx
@@ -26,6 +26,7 @@ export default function RegistrationForm({ onSubmit, initialData }) {
   const [otpCode, setOtpCode] = useState('');
   const [emailSent, setEmailSent] = useState(false);
   const [emailDispatched, setEmailDispatched] = useState(false);
+  const [investorId, setInvestorId] = useState(null);
 
   const registrationSchema = {
     full_name: [validationRules.required, validationRules.minLength(2)],
@@ -69,7 +70,9 @@ export default function RegistrationForm({ onSubmit, initialData }) {
         console.error('Email confirmation failed:', emailErr);
       }
 
-      await InvestorService.sendVerificationCode(form.values.phone);
+      const response = await InvestorService.sendVerificationCode(form.values.phone);
+      const data = response?.data || response;
+      setInvestorId(data?.investorId || data?.investor_id || data?.id || null);
       setShowOTP(true);
       success('Verification code sent successfully!');
     } catch (err) {
@@ -88,9 +91,7 @@ export default function RegistrationForm({ onSubmit, initialData }) {
     setIsLoading(true);
     
     try {
-      // In a real scenario, you'd verify OTP with the backend:
-      // await InvestorService.verifyOTP(form.values.phone, otpCode);
-      await new Promise(resolve => setTimeout(resolve, 500)); // Simulate API call (successful phone verification and account creation)
+      await InvestorService.verifyPhone(investorId, otpCode);
       if (emailDispatched) {
         setEmailSent(true);
         success('Account created! Please check your email to verify your account.');


### PR DESCRIPTION
## Summary
- Verify phone numbers using `InvestorService.verifyPhone`
- Store investor identifier returned from verification-code request

## Testing
- `npx vitest run` *(fails: No test files found)*
- `npm run lint` *(fails: React unused vars and fast refresh errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cbd7290e48325817e3bb4f4b34dc2