### PR TITLE
Render photo upload grid and use api client for file uploads

### DIFF
--- a/src/components/photos/PhotoUploadGrid.jsx
+++ b/src/components/photos/PhotoUploadGrid.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { UploadFile } from "@/api/integrations";
+import apiClient from "@/api/client";
 import { Upload, Trash2, CheckCircle, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -14,7 +14,7 @@ export default function PhotoUploadGrid({ onComplete, setUploadedPhotos, uploade
     if (files.length === 0) return;
 
     setIsUploading(true);
-    const uploadPromises = files.map(file => UploadFile({ file }));
+    const uploadPromises = files.map(file => apiClient.uploadFile('/files', file));
     
     try {
       const results = await Promise.all(uploadPromises);

--- a/src/pages/PhotoUpload.jsx
+++ b/src/pages/PhotoUpload.jsx
@@ -1,6 +1,23 @@
-export default function PhotoUpload(){
-  return <div>
-    <h1 className="text-2xl font-semibold mb-2">Photo Upload</h1>
-    <p>This page is being migrated from Base44. Coming soon.</p>
-  </div>;
+import { useState } from 'react';
+import PhotoUploadGrid from '@/components/photos/PhotoUploadGrid';
+
+export default function PhotoUpload() {
+  const [uploadedPhotos, setUploadedPhotos] = useState([]);
+
+  const handleComplete = () => {
+    // For now we just log the uploaded URLs; further actions can be added later
+    console.log('Uploaded photo URLs:', uploadedPhotos);
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-6">Photo Upload</h1>
+      <PhotoUploadGrid
+        uploadedPhotos={uploadedPhotos}
+        setUploadedPhotos={setUploadedPhotos}
+        onComplete={handleComplete}
+      />
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- Render `PhotoUploadGrid` in `PhotoUpload` and track uploaded photo URLs
- Replace legacy `UploadFile` helper with `apiClient.uploadFile` pointing to `/api` routes

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: 53 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cc96031348325957358c17d775a00