### PR TITLE
Create lead after photo upload or skip

### DIFF
--- a/src/components/services/leadService.js
+++ b/src/components/services/leadService.js
@@ -1,0 +1,10 @@
+import apiClient from '@/api/client';
+
+export class LeadService {
+  // Create a new lead
+  static async create(leadData) {
+    return await apiClient.post('/leads', leadData);
+  }
+}
+
+export default LeadService;

--- a/src/pages/PhotoUpload.jsx
+++ b/src/pages/PhotoUpload.jsx
@@ -1,12 +1,36 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createPageUrl } from '@/utils';
 import PhotoUploadGrid from '@/components/photos/PhotoUploadGrid';
+import LeadService from '@/components/services/leadService';
 
 export default function PhotoUpload() {
   const [uploadedPhotos, setUploadedPhotos] = useState([]);
+  const navigate = useNavigate();
 
-  const handleComplete = () => {
-    // For now we just log the uploaded URLs; further actions can be added later
-    console.log('Uploaded photo URLs:', uploadedPhotos);
+  const urlParams = new URLSearchParams(window.location.search);
+  const sellerIdParam = urlParams.get('seller_id');
+  const propertyIdParam = urlParams.get('property_id');
+
+  const handleComplete = async () => {
+    const storedProperty = JSON.parse(localStorage.getItem('moolahturtle_property')) || {};
+    const { sellerId: storedSellerId, ...property } = storedProperty;
+
+    const finalSellerId = sellerIdParam || storedSellerId;
+    const finalPropertyId = propertyIdParam || property.propertyId;
+
+    try {
+      await LeadService.create({
+        sellerId: finalSellerId,
+        property,
+        photos: uploadedPhotos,
+      });
+      localStorage.removeItem('moolahturtle_property');
+    } catch (error) {
+      console.error('Error creating lead:', error);
+    }
+
+    navigate(createPageUrl(`PropertyListed?seller_id=${finalSellerId}&property_id=${finalPropertyId}`));
   };
 
   return (
@@ -20,4 +44,3 @@ export default function PhotoUpload() {
     </div>
   );
 }
-

--- a/src/pages/PhotoUploadIntro.jsx
+++ b/src/pages/PhotoUploadIntro.jsx
@@ -3,12 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Camera, ArrowRight, SkipForward, Upload } from 'lucide-react';
+import { Camera, SkipForward, Upload } from 'lucide-react';
 import { motion } from 'framer-motion';
+import LeadService from '@/components/services/leadService';
 
 const AnimatedTurtle = () => (
   <motion.div
-    animate={{ 
+    animate={{
       y: [0, -8, 0],
       rotate: [0, 3, -3, 0]
     }}
@@ -32,7 +33,7 @@ export default function PhotoUploadIntro() {
     const urlParams = new URLSearchParams(window.location.search);
     const sellerIdParam = urlParams.get('seller_id');
     const propertyIdParam = urlParams.get('property_id');
-    
+
     if (sellerIdParam && propertyIdParam) {
       setSellerId(sellerIdParam);
       setPropertyId(propertyIdParam);
@@ -45,8 +46,24 @@ export default function PhotoUploadIntro() {
     navigate(createPageUrl(`PhotoUpload?seller_id=${sellerId}&property_id=${propertyId}`));
   };
 
-  const handleSkip = () => {
-    navigate(createPageUrl(`PropertyListed?seller_id=${sellerId}&property_id=${propertyId}`));
+  const handleSkip = async () => {
+    const storedProperty = JSON.parse(localStorage.getItem('moolahturtle_property')) || {};
+    const { sellerId: storedSellerId, ...property } = storedProperty;
+    const finalSellerId = sellerId || storedSellerId;
+    const finalPropertyId = propertyId || property.propertyId;
+
+    try {
+      await LeadService.create({
+        sellerId: finalSellerId,
+        property,
+        photos: [],
+      });
+      localStorage.removeItem('moolahturtle_property');
+    } catch (error) {
+      console.error('Error creating lead:', error);
+    }
+
+    navigate(createPageUrl(`PropertyListed?seller_id=${finalSellerId}&property_id=${finalPropertyId}`));
   };
 
   return (
@@ -56,7 +73,7 @@ export default function PhotoUploadIntro() {
           <div className="flex justify-center mb-6">
             <AnimatedTurtle />
           </div>
-          
+
           <motion.div
             initial={{ scale: 0, rotate: -90 }}
             animate={{ scale: 1, rotate: 0 }}
@@ -65,20 +82,20 @@ export default function PhotoUploadIntro() {
           >
             <Camera className="w-12 h-12 text-green-600" />
           </motion.div>
-          
+
           <CardTitle className="text-3xl lg:text-4xl font-bold">
             <span className="bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
               Almost There! Final Step
             </span>
           </CardTitle>
         </CardHeader>
-        
+
         <CardContent className="space-y-8">
           <div className="space-y-4">
             <p className="text-xl text-gray-700 leading-relaxed">
               Your property is almost listed in our marketplace. To help investors evaluate and make fair offers, we strongly encourage you to upload photos of your property.
             </p>
-            
+
             <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-6">
               <div className="flex items-center gap-3 mb-3">
                 <Upload className="w-6 h-6 text-yellow-600" />
@@ -91,27 +108,27 @@ export default function PhotoUploadIntro() {
                 <li>• Builds trust and confidence in your listing</li>
               </ul>
             </div>
-            
+
             <p className="text-lg text-gray-600">
               Uploading photos is <strong>optional</strong>, but <strong>highly recommended</strong>. Your choice—add photos now or skip this step.
             </p>
           </div>
-          
+
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-              <Button 
-                onClick={handleStartUpload} 
+              <Button
+                onClick={handleStartUpload}
                 className="w-full sm:w-auto py-6 px-8 text-lg bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 shadow-xl"
               >
                 <Camera className="mr-3 w-5 h-5" />
                 Upload Photos
               </Button>
             </motion.div>
-            
+
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-              <Button 
-                variant="outline" 
-                onClick={handleSkip} 
+              <Button
+                variant="outline"
+                onClick={handleSkip}
                 className="w-full sm:w-auto py-6 px-8 text-lg border-2 hover:bg-gray-50"
               >
                 <SkipForward className="mr-3 w-5 h-5" />


### PR DESCRIPTION
## Summary
- Add LeadService for posting leads via `/api/leads`
- Trigger lead creation after photo upload completion with seller and property data
- Handle skipping photo upload by creating the lead immediately

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, no-unused-vars, etc.)*
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccd9c5de88325aa9b905a17abd87a