### PR TITLE
Notify seller after lead creation and redirect to dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Register from "@/pages/Register.jsx";
 import InvestorRegistration from "@/pages/InvestorRegistration.jsx";
 import InvestorLogin from "@/pages/InvestorLogin.jsx";
 import InvestorDashboard from "@/pages/InvestorDashboard.jsx";
+import Dashboard from "@/pages/Dashboard.jsx";
 import ForgotPassword from "@/pages/ForgotPassword.jsx";
 import ResetPassword from "@/pages/ResetPassword.jsx";
 import EmailConfirmation from "@/pages/EmailConfirmation.jsx";
@@ -33,6 +34,7 @@ const pageComponents = {
   InvestorRegistration,
   InvestorLogin,
   InvestorDashboard,
+  Dashboard,
   ForgotPassword,
   EmailConfirmation,
   PropertyDetails,

--- a/src/components/services/leadService.js
+++ b/src/components/services/leadService.js
@@ -3,7 +3,13 @@ import apiClient from '@/api/client';
 export class LeadService {
   // Create a new lead
   static async create(leadData) {
-    return await apiClient.post('/leads', leadData);
+    const { data } = await apiClient.post('/leads', leadData);
+    try {
+      await apiClient.post(`/leads/${data.id}/notify-seller`);
+    } catch (error) {
+      console.error('Failed to notify seller:', error);
+    }
+    return data;
   }
 }
 

--- a/src/pages/PhotoUpload.jsx
+++ b/src/pages/PhotoUpload.jsx
@@ -18,19 +18,19 @@ export default function PhotoUpload() {
 
     const finalSellerId = sellerIdParam || storedSellerId;
     const finalPropertyId = propertyIdParam || property.propertyId;
+    const finalProperty = { ...property, propertyId: finalPropertyId };
 
     try {
       await LeadService.create({
         sellerId: finalSellerId,
-        property,
+        property: finalProperty,
         photos: uploadedPhotos,
       });
       localStorage.removeItem('moolahturtle_property');
     } catch (error) {
       console.error('Error creating lead:', error);
     }
-
-    navigate(createPageUrl(`PropertyListed?seller_id=${finalSellerId}&property_id=${finalPropertyId}`));
+    navigate(createPageUrl('Dashboard'));
   };
 
   return (

--- a/src/pages/PhotoUploadIntro.jsx
+++ b/src/pages/PhotoUploadIntro.jsx
@@ -51,19 +51,19 @@ export default function PhotoUploadIntro() {
     const { sellerId: storedSellerId, ...property } = storedProperty;
     const finalSellerId = sellerId || storedSellerId;
     const finalPropertyId = propertyId || property.propertyId;
+    const finalProperty = { ...property, propertyId: finalPropertyId };
 
     try {
       await LeadService.create({
         sellerId: finalSellerId,
-        property,
+        property: finalProperty,
         photos: [],
       });
       localStorage.removeItem('moolahturtle_property');
     } catch (error) {
       console.error('Error creating lead:', error);
     }
-
-    navigate(createPageUrl(`PropertyListed?seller_id=${finalSellerId}&property_id=${finalPropertyId}`));
+    navigate(createPageUrl('Dashboard'));
   };
 
   return (

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,6 +15,7 @@ export const routeMap = {
   InvestorRegistration: "/investor/register",
   InvestorLogin: "/investor/login",
   InvestorDashboard: "/investor/dashboard",
+  Dashboard: "/dashboard",
   ForgotPassword: "/forgot-password",
   ResetPassword: "/reset-password", // page for setting a new password via email token
   EmailConfirmation: "/email-confirmation",


### PR DESCRIPTION
## Summary
- send seller notification via `/api/leads/{id}/notify-seller` after creating a lead
- redirect to dashboard after lead creation from photo upload flows
- wire dashboard page into routing

## Testing
- `npm test` (no tests found)
- `npm run lint` (fails: Fast refresh only works when a file only exports components, plus other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689ccf0123fc832588227011fb89d409