### PR TITLE
refactor: export uploadFile helper

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -17,7 +17,7 @@ apiClient.interceptors.response.use(
 );
 
 // Helper for uploading files using multipart/form-data
-apiClient.uploadFile = async (endpoint, file) => {
+export const uploadFile = async (endpoint, file) => {
   const formData = new FormData();
   formData.append('file', file);
   const { data } = await apiClient.post(endpoint, formData, {

--- a/src/components/photos/PhotoUploadGrid.jsx
+++ b/src/components/photos/PhotoUploadGrid.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import apiClient from "@/api/client";
+import { uploadFile } from "@/api/client";
 import { Upload, Trash2, CheckCircle, Loader2 } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion as Motion, AnimatePresence } from 'framer-motion';
 
 export default function PhotoUploadGrid({ onComplete, setUploadedPhotos, uploadedPhotos }) {
   const [isUploading, setIsUploading] = useState(false);
@@ -14,7 +14,7 @@ export default function PhotoUploadGrid({ onComplete, setUploadedPhotos, uploade
     if (files.length === 0) return;
 
     setIsUploading(true);
-    const uploadPromises = files.map(file => apiClient.uploadFile('/files', file));
+    const uploadPromises = files.map(file => uploadFile('/files', file));
     
     try {
       const results = await Promise.all(uploadPromises);
@@ -41,7 +41,7 @@ export default function PhotoUploadGrid({ onComplete, setUploadedPhotos, uploade
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mb-6">
           <AnimatePresence>
             {uploadedPhotos.map((url) => (
-              <motion.div
+              <Motion.div
                 key={url}
                 layout
                 initial={{ opacity: 0, scale: 0.5 }}
@@ -58,7 +58,7 @@ export default function PhotoUploadGrid({ onComplete, setUploadedPhotos, uploade
                 >
                   <Trash2 className="w-4 h-4" />
                 </Button>
-              </motion.div>
+              </Motion.div>
             ))}
           </AnimatePresence>
 

--- a/src/components/services/propertyService.jsx
+++ b/src/components/services/propertyService.jsx
@@ -1,4 +1,4 @@
-import apiClient from '@/api/client';
+import apiClient, { uploadFile } from '@/api/client';
 
 export class PropertyService {
   // Create new property
@@ -26,14 +26,14 @@ export class PropertyService {
         categoryPhotos.forEach((photo, index) => {
           if (photo instanceof File) {
             uploadPromises.push(
-              apiClient.uploadFile(`/properties/${propertyId}/photos`, photo)
+              uploadFile(`/properties/${propertyId}/photos`, photo)
                 .then(result => ({ category, index, ...result }))
             );
           }
         });
       } else if (categoryPhotos instanceof File) {
         uploadPromises.push(
-          apiClient.uploadFile(`/properties/${propertyId}/photos`, categoryPhotos)
+          uploadFile(`/properties/${propertyId}/photos`, categoryPhotos)
             .then(result => ({ category, ...result }))
         );
       }


### PR DESCRIPTION
## Summary
- export standalone `uploadFile` helper from API client
- use `uploadFile` helper in photo grid and property service

## Testing
- `npm test`
- `npm run lint` *(fails: unused vars in unrelated pages)*
- `npx eslint src/api/client.js src/components/photos/PhotoUploadGrid.jsx src/components/services/propertyService.jsx && echo "eslint: no issues"`


------
https://chatgpt.com/codex/tasks/task_e_689cd5c267e483259982d5e22386a319