### PR TITLE
Use /api base path for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ To build and run the production container:
 ```bash
  docker-compose up --build
 ```
+
+## API Routes
+
+All frontend API requests are made through the shared `apiClient` configured with a `baseURL` of `/api`. The provided
+`nginx.conf` proxies all requests that begin with this prefix to the backend service. When adding new API routes, ensure
+their paths start with `/api` so they are correctly forwarded.

--- a/src/components/services/leadService.js
+++ b/src/components/services/leadService.js
@@ -3,16 +3,16 @@ import apiClient from '@/api/client';
 export class LeadService {
   // Create a new lead
   static async create(leadData) {
-    const { data } = await apiClient.post('/api/leads', leadData);
+    const { data } = await apiClient.post('/leads', leadData);
 
     try {
-      await apiClient.post(`/api/leads/${data.id}/notify-seller`);
+      await apiClient.post(`/leads/${data.id}/notify-seller`);
     } catch (error) {
       console.error('Failed to notify seller:', error);
     }
 
     try {
-      await apiClient.post(`/api/leads/${data.id}/notify-investors`);
+      await apiClient.post(`/leads/${data.id}/notify-investors`);
     } catch (error) {
       console.error('Failed to notify investors:', error);
     }


### PR DESCRIPTION
## Summary
- remove hardcoded `/api` prefixes from lead service to rely on shared axios client
- document required `/api` prefix for backend routes

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: see logs for detailed ESLint issues)*

------
https://chatgpt.com/codex/tasks/task_e_689cd8eebfe08325bd248884f1c40e08