### PR TITLE
Use cookie-based authentication

### DIFF
--- a/src/components/services/investorService.jsx
+++ b/src/components/services/investorService.jsx
@@ -9,9 +9,6 @@ export class InvestorService {
   // Login investor
   static async login(credentials) {
     const { data } = await apiClient.post('/auth/login', credentials);
-    if (data.token) {
-      apiClient.defaults.headers.common.Authorization = `Bearer ${data.token}`;
-    }
     return data;
   }
 
@@ -76,10 +73,7 @@ export class InvestorService {
 
   // Logout
   static async logout() {
-    delete apiClient.defaults.headers.common.Authorization;
-    localStorage.removeItem('token');
-    localStorage.removeItem('investorId');
-    localStorage.removeItem('investorEmail');
+    await apiClient.post('/auth/logout');
   }
 
   // Get all investors (admin only)

--- a/src/pages/InvestorLogin.jsx
+++ b/src/pages/InvestorLogin.jsx
@@ -45,7 +45,7 @@ export default function InvestorLogin() {
     setIsLoading(true);
     
     try {
-      const { token, user } = await InvestorService.login(form.values);
+      const { user } = await InvestorService.login(form.values);
 
       // Check if email is verified
       if (!user.email_verified) {
@@ -55,7 +55,7 @@ export default function InvestorLogin() {
         return;
       }
 
-      await authLogin(token, user);
+      await authLogin();
       success('Login successful! Redirecting to dashboard...');
       navigate(createPageUrl('InvestorDashboard'));
     } catch (err) {


### PR DESCRIPTION
## Summary
- Remove token-based auth logic and rely on server-issued cookies
- Update investor service and login flow for cookie auth
- Fetch user state from `/auth/me` and call `/auth/logout` on logout

## Testing
- `npm test -- --run` (fails: No test files found)
- `npm run lint` (fails: 52 errors, 4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689cdcc373f0832592267365fdcebfe2