### PR TITLE
Ensure server session invalidated on logout

### DIFF
--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -39,9 +39,11 @@ export const AuthProvider = ({ children }) => {
       await apiClient.post("/auth/logout");
     } catch {
       // ignore errors during logout
+    } finally {
+      document.cookie = "session=; Max-Age=0";
+      setUser(null);
+      setIsAuthenticated(false);
     }
-    setUser(null);
-    setIsAuthenticated(false);
   };
 
   useEffect(() => {

--- a/src/components/services/investorService.jsx
+++ b/src/components/services/investorService.jsx
@@ -73,7 +73,11 @@ export class InvestorService {
 
   // Logout
   static async logout() {
-    await apiClient.post('/auth/logout');
+    try {
+      await apiClient.post('/auth/logout');
+    } finally {
+      document.cookie = 'session=; Max-Age=0';
+    }
   }
 
   // Get all investors (admin only)


### PR DESCRIPTION
## Summary
- Post to `/auth/logout` and clear session cookie in auth provider
- Centralize investor service logout to clear server and cookie
- Protected dashboard redirects when session invalidated

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 52 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf7c02948325bfb0e7c719d0df86