### PR TITLE
Add unit test for SellerService register API call

### DIFF
--- a/src/components/services/__tests__/sellerService.test.js
+++ b/src/components/services/__tests__/sellerService.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the apiClient to intercept HTTP requests
+vi.mock('@/api/client', () => ({
+  default: { post: vi.fn() }
+}));
+
+import apiClient from '@/api/client';
+import SellerService from '@/components/services/sellerService';
+
+describe('SellerService.register', () => {
+  it('posts to /sellers/register with the provided data', async () => {
+    const payload = { name: 'Jane Doe', phone: '1234567890' };
+    apiClient.post.mockResolvedValue({ data: {} });
+
+    await SellerService.register(payload);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/sellers/register', payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying SellerService.register posts seller data to `/sellers/register`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce1219b108325863bb2d0a03cb85c