### PR TITLE
test: add LeadService notification test

### DIFF
--- a/src/components/services/__tests__/leadService.test.js
+++ b/src/components/services/__tests__/leadService.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  default: { post: vi.fn() },
+}));
+
+import apiClient from '@/api/client';
+import { LeadService } from '@/components/services/leadService';
+
+describe('LeadService.create', () => {
+  it('posts to /leads and triggers notifications', async () => {
+    const payload = { name: 'John Doe' };
+
+    apiClient.post
+      .mockResolvedValueOnce({ data: { id: 1 } })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await LeadService.create(payload);
+
+    expect(apiClient.post).toHaveBeenNthCalledWith(1, '/leads', payload);
+    expect(apiClient.post).toHaveBeenNthCalledWith(2, '/leads/1/notify-seller');
+    expect(apiClient.post).toHaveBeenNthCalledWith(3, '/leads/1/notify-investors');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for LeadService.create to ensure it posts to `/leads` and triggers seller and investor notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce5dee82c8325bbc317c3f3f6f7c8