### PR TITLE
Add InvestorService register tests

### DIFF
--- a/src/components/services/__tests__/investorService.test.js
+++ b/src/components/services/__tests__/investorService.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  default: { post: vi.fn() },
+}));
+
+import apiClient from '@/api/client';
+import { InvestorService } from '@/components/services/investorService';
+
+describe('InvestorService.register', () => {
+  it('posts to /investors/register and returns response data', async () => {
+    const payload = { name: 'Alice' };
+    const mockResponse = { data: { id: 123 } };
+    apiClient.post.mockResolvedValueOnce(mockResponse);
+
+    const result = await InvestorService.register(payload);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/investors/register', payload);
+    expect(result).toEqual(mockResponse.data);
+  });
+
+  it('propagates errors from apiClient.post', async () => {
+    const payload = { name: 'Bob' };
+    const error = new Error('Request failed');
+    apiClient.post.mockRejectedValueOnce(error);
+
+    await expect(InvestorService.register(payload)).rejects.toThrow(error);
+    expect(apiClient.post).toHaveBeenCalledWith('/investors/register', payload);
+  });
+});

--- a/src/components/services/investorService.jsx
+++ b/src/components/services/investorService.jsx
@@ -3,7 +3,8 @@ import apiClient from '@/api/client';
 export class InvestorService {
   // Register new investor
   static async register(investorData) {
-    return await apiClient.post('/investors/register', investorData);
+    const { data } = await apiClient.post('/investors/register', investorData);
+    return data;
   }
 
   // Login investor


### PR DESCRIPTION
## Summary
- Ensure InvestorService.register returns API data
- Test InvestorService.register for success and error responses

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689ce7f3f4ec8325a8137e8af46017b6